### PR TITLE
Wire frasermolyneux-copilot MCP server into portal-core

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,12 @@
 >
 > **Cloud agents (GitHub Copilot coding agent etc.):** read [`AGENTS.md`](../AGENTS.md) at the repo root first — it is the canonical brief that survives outside the local VS Code multi-root workspace.
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
 ## Project Overview
 
 This is a Terraform-only repository that provisions shared portal infrastructure on Azure. It manages Application Insights, app service plans, a managed-identity-backed SQL server, portal dashboards, and resource health alerting. All infrastructure code lives under the `terraform/` directory.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -7,7 +7,17 @@
       "env": {
         "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
       },
-      "tools": ["*"]
+      "tools": [
+        "list_instructions",
+        "get_instruction",
+        "search_instructions",
+        "list_prompts",
+        "get_prompt",
+        "search_prompts",
+        "list_agents",
+        "get_agent",
+        "search_agents"
+      ]
     }
   }
 }

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,3 +33,15 @@ jobs:
         with:
           repository: frasermolyneux/.github-copilot
           path: .github-copilot
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - name: Build MCP server
+        shell: bash
+        run: |
+          cd .github-copilot/mcp-server
+          npm ci
+          npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,14 @@ The `copilot-setup-steps.yml` workflow checks out `frasermolyneux/.github-copilo
 
 ---
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
+---
+
 ## Stack guardrails
 
 ### Tenant facts (always-on)

--- a/README.md
+++ b/README.md
@@ -33,3 +33,25 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 ## Security
 
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+---
+
+## Local dev: MCP wire-up
+
+The cloud-runner coding agent gets the `frasermolyneux-copilot` MCP server automatically via [`.github/workflows/copilot-setup-steps.yml`](.github/workflows/copilot-setup-steps.yml) + [`.github/copilot/mcp_config.json`](.github/copilot/mcp_config.json). For local VS Code, wire it up at the **user level** (not committed) by adding to your user `mcp.json` (Command Palette → "MCP: Open User Configuration"):
+
+```json
+{
+  "servers": {
+    "frasermolyneux-copilot": {
+      "command": "node",
+      "args": ["<absolute path to your .github-copilot clone>/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": "<absolute path to your .github-copilot clone>"
+      }
+    }
+  }
+}
+```
+
+Build the server once after cloning: `cd <your .github-copilot clone>/mcp-server && npm ci && npm run build`.


### PR DESCRIPTION
## Summary

Pilot wire-up of the new `frasermolyneux-copilot` stdio MCP server (built in `frasermolyneux/.github-copilot/mcp-server/`) into `portal-core`, so the GitHub Copilot coding agent launches it on cloud runs and local devs know how to wire it. Strictly additive — once this proves out, the pattern rolls to every other `portal-*` / `mx-*` repo.

Closes N/A (no source issue — direct request from Fraser)

### Type of change

- [ ] bugfix
- [ ] feature
- [x] chore / refactor
- [x] docs
- [ ] infra (Terraform)
- [x] ci (GitHub Actions / Dependabot)
- [ ] dependencies
- [ ] breaking change

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules — git hands-off, code-review before done; PR creation was an explicit user override here)
- [ ] Stack-specific instruction files referenced in `AGENTS.md` (`standards.*`, `patterns.*`, `platform.*`, `shared.*`) — change is org-tooling, not Terraform/Azure

## Validation evidence

No Terraform / app build in scope. Validation focused on YAML/JSON correctness and the byte-identity guarantee for the canonical MCP snippet.

### Build

```text
N/A — docs + workflow + config only, no compile step in this repo.
```

### Tests

```text
N/A — no test suite for these surfaces. End-to-end validation requires a live cloud-agent run (see Reviewer focus areas).
```

### Format check

```text
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/copilot-setup-steps.yml'))"
(no output = parse ok)

$ python -c "import json; json.load(open('.github/copilot/mcp_config.json'))"
(no output = parse ok)
```

### Other (lint, terraform plan summary, screenshots)

Byte-identity check of the canonical `## Org conventions via MCP (when available)` block in both `.github/copilot-instructions.md` and `AGENTS.md`:

```text
copilot-instructions snippet sha256: DDAC8AA449794730F687EA61759C392D45C6C4E6C7A85C608EF365E15E748F6B (1094 chars)
AGENTS.md snippet sha256:            DDAC8AA449794730F687EA61759C392D45C6C4E6C7A85C608EF365E15E748F6B (1094 chars)
identical: True
```

## Risk and rollout

- **Blast radius:** GitHub Copilot coding-agent cloud runs for this repo only. The existing `copilot-setup-steps.yml` hook gains two new steps; if the new `npm ci`/`npm run build` step fails, the coding agent fails to start on this repo (other repos unaffected). No Azure / runtime impact.
- **Auto-deploys on merge?** No. Pure tooling/docs.
- **Manual steps post-merge:** None for infra. To validate the wire-up: assign a fresh issue to the Copilot coding agent and watch its session log for `frasermolyneux-copilot.*` tool calls (or an MCP startup error).
- **Rollback plan:** Revert this commit. Single commit, no schema/state changes.

## Reviewer focus areas

A few things worth a careful look:

1. **`.github/copilot/mcp_config.json` schema.** The original spec used `${{ github.workspace }}` and omitted `type`/`tools`. The `code-review` sub-agent flagged that (a) coding-agent MCP config does **not** evaluate Actions expression syntax (only `$VAR` / `${VAR}` / `${COPILOT_MCP_*}`), and (b) `type` + `tools` are required keys per the docs. Both fixed: switched to relative paths (agent cwd is the workspace) and added `"type": "local"` + `"tools": ["*"]`. The runtime expansion behaviour can only really be confirmed by a live coding-agent run on this branch.
2. **`npm ci` upstream dependency.** The `Build MCP server` step uses `npm ci`, which hard-fails if `frasermolyneux/.github-copilot/mcp-server/package-lock.json` is not committed upstream. Worth confirming the lockfile is in place before merge, or swap to `npm install --no-audit --no-fund`.
3. **SHA pin style mismatch.** `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4` follows the universal workflow standards (SHA pin), but the adjacent `actions/checkout@v6` in the same file is tag-pinned. Happy to swap to `@v4` for local consistency if preferred.
4. **VS Code wire-up is docs-only.** Chose Option B (README section, no committed `.vscode/mcp.json`) for portability — every dev clones `.github-copilot` to a different path. If you want a committed `.vscode/mcp.json` later, easy follow-up.

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas** (two Highs fixed, one Medium surfaced as point 2)
- [x] PR body cites each acceptance criterion from the linked issue (no source issue — direct user request; all task acceptance points addressed)
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)