### PR TITLE
Refresh README and relocate local MCP wire-up doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Dependabot Auto-Merge](https://github.com/frasermolyneux/portal-core/actions/workflows/dependabot-automerge.yml/badge.svg)](https://github.com/frasermolyneux/portal-core/actions/workflows/dependabot-automerge.yml)
 [![Deploy Dev](https://github.com/frasermolyneux/portal-core/actions/workflows/deploy-dev.yml/badge.svg)](https://github.com/frasermolyneux/portal-core/actions/workflows/deploy-dev.yml)
 [![Deploy Prd](https://github.com/frasermolyneux/portal-core/actions/workflows/deploy-prd.yml/badge.svg)](https://github.com/frasermolyneux/portal-core/actions/workflows/deploy-prd.yml)
-[![Destroy Development](https://github.com/frasermolyneux/portal-core/actions/workflows/destroy-development.yml/badge.svg)](https://github.com/frasermolyneux/portal-core/actions/workflows/destroy-development.yml)
 [![Destroy Environment](https://github.com/frasermolyneux/portal-core/actions/workflows/destroy-environment.yml/badge.svg)](https://github.com/frasermolyneux/portal-core/actions/workflows/destroy-environment.yml)
+[![Mirror Issue Labels](https://github.com/frasermolyneux/portal-core/actions/workflows/mirror-issue-labels.yml/badge.svg)](https://github.com/frasermolyneux/portal-core/actions/workflows/mirror-issue-labels.yml)
 [![PR Verify](https://github.com/frasermolyneux/portal-core/actions/workflows/pr-verify.yml/badge.svg)](https://github.com/frasermolyneux/portal-core/actions/workflows/pr-verify.yml)
 [![Update Dashboard from Staging](https://github.com/frasermolyneux/portal-core/actions/workflows/update-dashboard-from-staging.yml/badge.svg)](https://github.com/frasermolyneux/portal-core/actions/workflows/update-dashboard-from-staging.yml)
 
@@ -15,43 +15,16 @@
 
 * [Development Workflows](/docs/development-workflows.md) - Branch strategy, CI/CD triggers, and development flows
 * [Terraform Resource Standards](/docs/tf-resource-standards.md) - Naming and tagging conventions for Azure resources
-
----
+* [Local MCP Wire-Up](/docs/local-mcp-wire-up.md) - Configuring the `frasermolyneux-copilot` MCP server for local VS Code
 
 ## Overview
 
 This repository contains the Terraform infrastructure-as-code for the portal-core shared services layer. It provisions Application Insights, app service plans, a managed-identity-backed SQL server, portal dashboards, and resource health alerting across development and production environments. State is hydrated from upstream remote states including platform-workloads, platform-monitoring, and portal-environments. GitHub Actions workflows handle CI validation, environment deployments, and promotion from development to production via reusable pipelines.
 
----
-
 ## Contributing
 
 Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and development project.
 
----
-
 ## Security
 
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
-
----
-
-## Local dev: MCP wire-up
-
-The cloud-runner coding agent gets the `frasermolyneux-copilot` MCP server automatically via [`.github/workflows/copilot-setup-steps.yml`](.github/workflows/copilot-setup-steps.yml) + [`.github/copilot/mcp_config.json`](.github/copilot/mcp_config.json). For local VS Code, wire it up at the **user level** (not committed) by adding to your user `mcp.json` (Command Palette → "MCP: Open User Configuration"):
-
-```json
-{
-  "servers": {
-    "frasermolyneux-copilot": {
-      "command": "node",
-      "args": ["<absolute path to your .github-copilot clone>/mcp-server/dist/index.js"],
-      "env": {
-        "GH_COPILOT_CONTENT_ROOT": "<absolute path to your .github-copilot clone>"
-      }
-    }
-  }
-}
-```
-
-Build the server once after cloning: `cd <your .github-copilot clone>/mcp-server && npm ci && npm run build`.

--- a/docs/local-mcp-wire-up.md
+++ b/docs/local-mcp-wire-up.md
@@ -1,0 +1,19 @@
+# Local dev: MCP wire-up
+
+The cloud-runner coding agent gets the `frasermolyneux-copilot` MCP server automatically via [`.github/workflows/copilot-setup-steps.yml`](/.github/workflows/copilot-setup-steps.yml) + [`.github/copilot/mcp_config.json`](/.github/copilot/mcp_config.json). For local VS Code, wire it up at the **user level** (not committed) by adding to your user `mcp.json` (Command Palette → "MCP: Open User Configuration"):
+
+```json
+{
+  "servers": {
+    "frasermolyneux-copilot": {
+      "command": "node",
+      "args": ["<absolute path to your .github-copilot clone>/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": "<absolute path to your .github-copilot clone>"
+      }
+    }
+  }
+}
+```
+
+Build the server once after cloning: `cd <your .github-copilot clone>/mcp-server && npm ci && npm run build`.


### PR DESCRIPTION
## Summary

End-to-end validation run of the new `frasermolyneux-copilot` MCP server: drove the `update-project-metadata` agent against `portal-core` fetching all canonical content via MCP (no local `.github-copilot/` reads, no web fetch). The agent run found two real drift items in `README.md` worth fixing.

Closes #

## Type of change

- [x] chore / refactor
- [x] docs

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md` (`standards.*`, `patterns.*`, `platform.*`, `shared.*`)

The four `metadata.*.instructions.md` files and the four `update-*.prompt.md` shims were all fetched via the MCP catalog (`get_instruction`, `get_prompt`) — not from disk.

## Validation evidence

### Build

```text
N/A — docs-only change.
```

### Tests

```text
N/A — docs-only change.
```

### Format check

```text
N/A — no Terraform / .NET files touched.
```

### Other (lint, terraform plan summary, screenshots)

`code-review` sub-agent run over the diff with full canonical-file context. Result: no High/Medium findings. One Low finding (two badge display names are sentence-case derivations of filenames rather than verbatim YAML `name:` values) — defensible under the canonical wording (`"typically the value of name: in the YAML, or a sentence-case derivation of the filename"`) and left as-is.

`CONTRIBUTING.md`, `SECURITY.md`, and `.github/copilot-instructions.md` were checked against canonical and are already compliant — no changes made to those files. The recently-added `## Org conventions via MCP (when available)` snippet in `.github/copilot-instructions.md` was preserved verbatim.

## Risk and rollout

- **Blast radius:** None at runtime. Docs / README only; no Terraform, workflows, or app code touched.
- **Auto-deploys on merge?** No.
- **Manual steps post-merge:** None.
- **Rollback plan:** Revert the merge commit.

## Reviewer focus areas

- The "Local dev: MCP wire-up" prose was moved out of `README.md` into `docs/local-mcp-wire-up.md` rather than deleted — the canonical README rules forbid inline command snippets but the content is still useful. Shout if you'd rather drop it.
- Stale `destroy-development.yml` badge removed (no such workflow file on disk); `mirror-issue-labels.yml` badge added to complete the 1-badge-per-workflow rule.

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas**
- [x] PR body cites each acceptance criterion from the linked issue
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)