### PR TITLE
ci: pin shared .github-copilot checkout to v0.1.0

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           repository: frasermolyneux/.github-copilot
           path: .github-copilot
+          ref: refs/tags/v0.1.0
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4


### PR DESCRIPTION
## Summary

Pin the runner's checkout of `frasermolyneux/.github-copilot` to the newly-cut `v0.1.0` tag so cloud Copilot agents see a stable, immutable version of the shared instruction catalog and MCP server instead of drifting with the default branch.

## Type of change

- [x] CI / tooling

## Validation evidence

```text
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/copilot-setup-steps.yml')); print('YAML OK')"
YAML OK

$ git diff --stat
 .github/workflows/copilot-setup-steps.yml | 1 +
 1 file changed, 1 insertion(+)
```

Verified out-of-band that tag `v0.1.0` exists on `frasermolyneux/.github-copilot` (sha `7fd50ae`) and contains a buildable `mcp-server/` tree (`package.json`, `package-lock.json`, `tsconfig.json`, `src/`, `scripts/`) so the subsequent `npm ci && npm run build` step remains valid. All 13 instruction files referenced from `AGENTS.md` exist at the pinned tag.

## Risk and rollout

- **Blast radius:** Local to this repo's Copilot cloud-agent runner. No production infra changed.
- **Auto-deploy:** No. Workflow only runs when the agent boots.
- **Manual steps post-merge:** None.
- **Rollback:** Revert this one-line change (or bump `ref:` to a newer tag) and re-run.

## Consumer impact

No published Terraform output, NuGet, or Service Bus DTO changed.

## Agent attestation

- [x] Diff is minimal and on-scope (one line in one file).
- [x] `terraform fmt -check` / `validate` not applicable - no Terraform changed.
- [x] No new secrets, GUIDs, or connection strings introduced.
- [x] No outputs added or renamed; no downstream `portal-*` consumer audit needed.
- [x] `code-review` sub-agent run; no High/Medium findings.

## Follow-ups (not in this PR)

1. Same workflow has inconsistent action pinning: `actions/setup-node` is SHA-pinned but both `actions/checkout@v6` usages are only major-pinned. Worth a cross-repo cleanup sweep.
2. Sibling `portal-*` / `platform-*` stacks that also clone `frasermolyneux/.github-copilot` probably want the same `refs/tags/v0.1.0` pin for consistency.